### PR TITLE
Meal page comment and some fix

### DIFF
--- a/bridge_front/src/components/meal.js
+++ b/bridge_front/src/components/meal.js
@@ -3,27 +3,36 @@ import MealList from './meal_list';
 import styles from './style/meal.module.css';
 import ProgressBar from "react-animated-progress-bar";
 import Calendar from "react-calendar";
-import 'react-calendar/dist/Calendar.css';
+import './style/calendar.css'
 import moment from 'moment';
 import 'moment/locale/ko';
 import styled from 'styled-components';
 
+// 각 부분 구분하는 가로 줄
 const StyledHr = styled.hr`
+    margin-left: 10%;
+    margin-right: 10%;
     width: 80%;
 `;
 
 const Meal = (props) => {
+    //Progress bar 퍼센트 state
     const [percent, setPercent] = useState(0);
+    //캘린더에서 선택한 날짜를 담는 state
     const [currentDate, setCurrentDate] = useState();
+    //캘린더에서 선택한 날짜의 목표 칼로리 기본값 1-> Divide by 0 오류 피하기 위해 1로 기본
     const [targetCal, setTargetCal] = useState(1);
 
+    //캘린더에서 클릭을 하면 (Focus on change)
     const calendarOnChange = (e) => {
         setCurrentDate(moment(e).format("YYYY-MM-DD"))
     };
 
+    //해더 버튼이 바라보는 Ref
     const todayRef = useRef();
     const monthlyRef = useRef();
     
+    //헤더 버튼 onClick handler
     const onTodayClick = () => {
         todayRef.current?.scrollIntoView({ behavior: 'smooth' });
     };

--- a/bridge_front/src/components/meal_list.js
+++ b/bridge_front/src/components/meal_list.js
@@ -30,7 +30,7 @@ const StyledMealList = styled.div`
 const StyledMealItem = styled.div`
     display: ${(props) => props.display}
 `
-
+//~에 ~만큼 먹었어요를 감싸는 Wrapper
 const MealItemFlexer = styled.div`
     display:flex;
     justfy-content: space-between;
@@ -60,12 +60,14 @@ const StyledInput = styled.input`
 const StyledSender = styled.button`
     width: 8vw;
     height: 5vh;
+    margin-top: 2vh;
     border: none;
     border-radius: 8px;
     background-color: skyblue;
     opacity: 0.6;
     font-family: Pretended;
     cursor: pointer;
+    
     display: ${(props) => props.sender_display};
     :hover{
         opacity: 1;
@@ -75,9 +77,9 @@ const StyledSender = styled.button`
 //Component
 const MealList = (props) => {
     //아침, 점심, 저녁 버튼 아래에 있는 div display 상태
-    const [breakfast, setBreakfast] = useState('none');
-    const [lunch, setLunch] = useState('none');
-    const [dinner, setDinner] = useState('none');
+    const [breakfast, setBreakfast] = useState('block');
+    const [lunch, setLunch] = useState('block');
+    const [dinner, setDinner] = useState('block');
 
     //아침, 점심, 저녁에 먹은 칼로리를 입력 받게 되는 State
     const [breakfastValue, setBreakfastValue] = useState(0)
@@ -87,11 +89,11 @@ const MealList = (props) => {
     //아침 버튼을 클릭하면 나오고 사라지고
     const handleBreakfastClick = () => {
         if (!breakfast_v) {
-            setBreakfast('block');
+            setBreakfast('none');
             breakfast_v = true;
         }
         else {
-            setBreakfast('none');
+            setBreakfast('block');
             breakfast_v = false;
         }
     };
@@ -99,11 +101,11 @@ const MealList = (props) => {
     //점심 버튼을 클릭하면 나오고 사라지고
     const handleLunchClick = () => {
         if (!lunch_v) {
-            setLunch('block')
+            setLunch('none')
             lunch_v = true;
         }
         else {
-            setLunch('none')
+            setLunch('block')
             lunch_v = false;
         }
     }
@@ -111,11 +113,11 @@ const MealList = (props) => {
     //저녁 버튼을 클릭하면 나오고 사라지고
     const handleDinnerClick = () => {
         if (!dinner_v) {
-            setDinner('block')
+            setDinner('none')
             dinner_v = true;
         }
         else {
-            setDinner('none')
+            setDinner('block')
             dinner_v = false;
         }
     }
@@ -161,7 +163,7 @@ const MealList = (props) => {
                 </MealItemFlexer>
             </StyledMealItem>
 
-            <StyledSender onClick={dataSender} display={props.sender_display}>
+            <StyledSender onClick={dataSender} sender_display={props.sender_display}>
                 전송
             </StyledSender>
         </StyledWrapper> 

--- a/bridge_front/src/components/style/calendar.css
+++ b/bridge_front/src/components/style/calendar.css
@@ -1,0 +1,144 @@
+.react-calendar {
+    width: 350px;
+    max-width: 100%;
+    background: white;
+    border: 1px solid #a0a096;
+    font-family: Arial, Helvetica, sans-serif;
+    line-height: 1.125em;
+  }
+  
+  .react-calendar--doubleView {
+    width: 700px;
+  }
+  
+  .react-calendar--doubleView .react-calendar__viewContainer {
+    display: flex;
+    margin: -0.5em;
+  }
+  
+  .react-calendar--doubleView .react-calendar__viewContainer > * {
+    width: 50%;
+    margin: 0.5em;
+  }
+  
+  .react-calendar,
+  .react-calendar *,
+  .react-calendar *:before,
+  .react-calendar *:after {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+  }
+  
+  .react-calendar button {
+    margin: 0;
+    border: 0;
+    outline: none;
+  }
+  
+  .react-calendar button:enabled:hover {
+    cursor: pointer;
+  }
+  
+  .react-calendar__navigation {
+    display: flex;
+    height: 44px;
+    margin-bottom: 1em;
+  }
+  
+  .react-calendar__navigation button {
+    min-width: 44px;
+    background: none;
+  }
+  
+  .react-calendar__navigation button:disabled {
+    background-color: #f0f0f0;
+  }
+  
+  .react-calendar__navigation button:enabled:hover,
+  .react-calendar__navigation button:enabled:focus {
+    background-color: #e6e6e6;
+  }
+  
+  .react-calendar__month-view__weekdays {
+    text-align: center;
+    text-transform: uppercase;
+    font-weight: bold;
+    font-size: 0.75em;
+  }
+  
+  .react-calendar__month-view__weekdays__weekday {
+    padding: 0.5em;
+  }
+  
+  .react-calendar__month-view__weekNumbers .react-calendar__tile {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75em;
+    font-weight: bold;
+  }
+  
+  .react-calendar__month-view__days__day--weekend {
+    color: #d10000;
+  }
+  
+  .react-calendar__month-view__days__day--neighboringMonth {
+    color: #757575;
+  }
+  
+  .react-calendar__year-view .react-calendar__tile,
+  .react-calendar__decade-view .react-calendar__tile,
+  .react-calendar__century-view .react-calendar__tile {
+    padding: 2em 0.5em;
+  }
+  
+  .react-calendar__tile {
+    max-width: 100%;
+    padding: 10px 6.6667px;
+    background: none;
+    text-align: center;
+    line-height: 16px;
+  }
+  
+  .react-calendar__tile:disabled {
+    background-color: #f0f0f0;
+  }
+  
+  .react-calendar__tile:enabled:hover,
+  .react-calendar__tile:enabled:focus {
+    background-color: #e6e6e6;
+  }
+  
+  .react-calendar__tile--now {
+    background: #ffff76;
+  }
+  
+  .react-calendar__tile--now:enabled:hover,
+  .react-calendar__tile--now:enabled:focus {
+    background: #ffffa9;
+  }
+  
+  .react-calendar__tile--hasActive {
+    background: #76baff;
+  }
+  
+  .react-calendar__tile--hasActive:enabled:hover,
+  .react-calendar__tile--hasActive:enabled:focus {
+    background: #a9d4ff;
+  }
+  
+  .react-calendar__tile--active {
+    background: #006edc;
+    color: white;
+  }
+  
+  .react-calendar__tile--active:enabled:hover,
+  .react-calendar__tile--active:enabled:focus {
+    background: #1087ff;
+  }
+  
+  .react-calendar--selectRange .react-calendar__tile--hover {
+    background-color: #e6e6e6;
+  }
+  

--- a/bridge_front/src/components/style/meal.module.css
+++ b/bridge_front/src/components/style/meal.module.css
@@ -27,6 +27,7 @@
 }
 
 /*header buttons*/
+/*헤더 좌측 버튼*/
 #header_today_ref_btn{
     width: 8vw;
     height: 5vh;
@@ -37,9 +38,11 @@
     background-color: skyblue;
     font-family: Pretended;
 }
+/*헤더 좌측 버튼 호버링*/
 #header_today_ref_btn:hover{
     opacity: 1;
 }
+/*헤더 우측 버튼*/
 #header_monthly_ref_btn{
     width: 8vw;
     height: 5vh;
@@ -51,6 +54,7 @@
     font-family: Pretended;
     margin-left: 1rem;
 }
+/*헤더 우측 버튼 호버링*/
 #header_montly_ref_btn:hover{
     opacity: 1;
 }
@@ -123,12 +127,14 @@
     height: fit-content;
 }
 
+/*하루 목표 칼로리 설정 부분 Wrapper*/
 .meal_list_target_cal{
     width: 100%;
     display: flex;
     justify-content: space-between;
 }
 
+/*하루 목표 칼로리 숫자 적는 input*/
 .target_cal_receiver{
     width: 8vw;
     height: 5vh;
@@ -138,6 +144,7 @@
     font-family: Pretended;
 }
 
+/*하루 목표 칼로리 전송 버튼*/
 .target_cal_sender{
     width: 8vw;
     height: 5vh;
@@ -149,6 +156,7 @@
     font-family: Pretended;
     
 }
+/*하루 목표 칼로리 전송 버튼 호버링*/
 .target_cal_sender:hover{
     opacity: 1;
 }


### PR DESCRIPTION
1. 캘린더 css 뽑아오기 완료 -> 이제 원하는대로 수정이 가능
2. Meal 주석 추가 완료
3. Meal 우측 버튼 기본값을 펼쳐놓는 것으로 변경
4. Meal 오늘의 식단에서만 전송 버튼을 없애는 것으로 변경
5. 다만 4 의 변경에 따른 side-effect로 월간 식단 계획(하단)의 전송 버튼이 좌측 정렬이 되어버림 ( 해결 필요 )